### PR TITLE
add ghostty

### DIFF
--- a/configurations/modules/common/system-pkgs.nix
+++ b/configurations/modules/common/system-pkgs.nix
@@ -40,7 +40,7 @@
    virt-viewer
 
    ### Other
-   ptyxis
+   ghostty
    gnome-tweaks
 
    ### Themes

--- a/configurations/modules/specific/desktop/gnome.nix
+++ b/configurations/modules/specific/desktop/gnome.nix
@@ -50,6 +50,12 @@
             icon-theme = "Papirus-Dark";
             show-battery-percentage = true;
          };
+         "org/gnome/shell/extensions/blur-my-shell/application" = {
+           whitelist = [
+             "com.mitchellh.ghostty"
+             "zen"
+           ];
+         };
          "org/gnome/shell/extensions/dash-to-dock" = {
             dock-position = "LEFT";
             transparency-mode = "DYNAMIC";

--- a/configurations/modules/specific/desktop/gnome.nix
+++ b/configurations/modules/specific/desktop/gnome.nix
@@ -53,7 +53,6 @@
          "org/gnome/shell/extensions/blur-my-shell/application" = {
            whitelist = [
              "com.mitchellh.ghostty"
-             "zen"
            ];
          };
          "org/gnome/shell/extensions/dash-to-dock" = {

--- a/configurations/modules/specific/desktop/gnome.nix
+++ b/configurations/modules/specific/desktop/gnome.nix
@@ -24,7 +24,15 @@
    yelp              ### Gnome help
    gnome-maps        ### Gnome maps
    gnome-connections ### Gnome connections
+   gnome-console     ### Gnome console (default term)
  ];
+
+
+ ### Nautilus settings
+ programs.nautilus-open-any-terminal = {
+   enable = true;
+   terminal = "ghostty";
+ };
 
 ###-------------------------------------------------------------------------
 
@@ -53,6 +61,7 @@
          "org/gnome/shell/extensions/blur-my-shell/application" = {
            whitelist = [
              "com.mitchellh.ghostty"
+             "zen"
            ];
          };
          "org/gnome/shell/extensions/dash-to-dock" = {

--- a/configurations/modules/specific/desktop/gnome.nix
+++ b/configurations/modules/specific/desktop/gnome.nix
@@ -48,7 +48,6 @@
             color-scheme = "prefer-dark";
             gtk-theme = "Adwaita-dark";
             icon-theme = "Papirus-Dark";
-            monospace-font-name = "UbuntuMono Nerd Font 10";
             show-battery-percentage = true;
          };
          "org/gnome/shell/extensions/dash-to-dock" = {
@@ -93,19 +92,10 @@
              "virt-manager.desktop"
              "org.prismlauncher.PrismLauncher.desktop"
              "spotify.desktop" 
-             "discord.desktop" 
+             "vesktop.desktop" 
              "steam.desktop"
              "LocalSend.desktop"
            ];
-         };
-         "org/gnome/Ptyxis" = {
-           audible-bell = false;
-           restore-session = false;
-           default-profile-uuid = "60b6639cc65c5a313600a657672c34f4";
-           profile-uuids =  ["60b6639cc65c5a313600a657672c34f4"];
-         };
-         "org/gnome/Ptyxis/Profiles/60b6639cc65c5a313600a657672c34f4" = {
-           palette = "Breath Darker";
          };
          "org/gnome/nautilus/preferences" = {
            show-create-link = true;

--- a/hm-profiles/desktop-profile.nix
+++ b/hm-profiles/desktop-profile.nix
@@ -6,6 +6,7 @@
    [ ../home-manager/home.nix                                   ### Common configuration
      ../home-manager/modules/common/custom-pkgs.nix             ### Related to custom pkgs
      ../home-manager/modules/customization/theme.nix            ### Related to theme configuration
+     ../home-manager/modules/customization/apps.nix             ### Related to app config
      ../home-manager/modules/customization/cli-app.nix          ### Related to cli software configuration
      ../home-manager/modules/desktop/gui-packages.nix           ### Related to GUI packages (need to use with a DE)
    ];

--- a/home-manager/dotfiles/ghostty/config
+++ b/home-manager/dotfiles/ghostty/config
@@ -44,10 +44,6 @@
 
 theme = "Molokai"
 background-opacity = 0.7
-font-family = "UbuntuMono Nerd Font"
-font-family-bold = "UbuntuMono Nerd Font Bold"
-font-family-italic = "UbuntuMono Nerd Font Italic"
-font-family-bold-italic = "UbuntuMono Nerd Font Bold Italic"
 font-size = 10
 
 

--- a/home-manager/dotfiles/ghostty/config
+++ b/home-manager/dotfiles/ghostty/config
@@ -44,10 +44,10 @@
 
 theme = "Molokai"
 background-opacity = 0.7
-font-family = "UbuntuMono Nerd Font Mono"
-font-family-bold = "UbuntuMono Nerd Font Mono Bold"
-font-family-italic = "UbuntuMono Nerd Font Mono Italic"
-font-family-bold-italic = "UbuntuMono Nerd Font Mono Bold Italic"
+font-family = "UbuntuMono Nerd Font"
+font-family-bold = "UbuntuMono Nerd Font Bold"
+font-family-italic = "UbuntuMono Nerd Font Italic"
+font-family-bold-italic = "UbuntuMono Nerd Font Bold Italic"
 font-size = 10
 
 

--- a/home-manager/dotfiles/ghostty/config
+++ b/home-manager/dotfiles/ghostty/config
@@ -1,0 +1,53 @@
+# This is the configuration file for Ghostty.
+#
+# This template file has been automatically created at the following
+# path since Ghostty couldn't find any existing config files on your system:
+#
+#   /home/minegame/.config/ghostty/config
+#
+# The template does not set any default options, since Ghostty ships
+# with sensible defaults for all options. Users should only need to set
+# options that they want to change from the default.
+#
+# Run `ghostty +show-config --default --docs` to view a list of
+# all available config options and their default values.
+#
+# Additionally, each config option is also explained in detail
+# on Ghostty's website, at https://ghostty.org/docs/config.
+
+# Config syntax crash course
+# ==========================
+# # The config file consists of simple key-value pairs,
+# # separated by equals signs.
+# font-family = Iosevka
+# window-padding-x = 2
+#
+# # Spacing around the equals sign does not matter.
+# # All of these are identical:
+# key=value
+# key= value
+# key =value
+# key = value
+#
+# # Any line beginning with a # is a comment. It's not possible to put
+# # a comment after a config option, since it would be interpreted as a
+# # part of the value. For example, this will have a value of "#123abc":
+# background = #123abc
+#
+# # Empty values are used to reset config keys to default.
+# key =
+#
+# # Some config options have unique syntaxes for their value,
+# # which is explained in the docs for that config option.
+# # Just for example:
+# resize-overlay-duration = 4s 200ms
+
+theme = "Molokai"
+background-opacity = 0.7
+font-family = "UbuntuMono Nerd Font Mono"
+font-family-bold = "UbuntuMono Nerd Font Mono Bold"
+font-family-italic = "UbuntuMono Nerd Font Mono Italic"
+font-family-bold-italic = "UbuntuMono Nerd Font Mono Bold Italic"
+font-size = 10
+
+

--- a/home-manager/modules/customization/apps.nix
+++ b/home-manager/modules/customization/apps.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }:
+
+{
+ # Home Manager needs a bit of information about you and the paths it should
+ # manage.
+ home = {
+   username = "minegame";
+   homeDirectory = "/home/minegame";
+ };
+
+ ### Install theme on home directory
+ home.file = {
+   ### Ghostty
+   ".config/ghostty/config".source = ../../dotfiles/ghostty/config
+ };
+ 
+}

--- a/home-manager/modules/customization/apps.nix
+++ b/home-manager/modules/customization/apps.nix
@@ -11,7 +11,7 @@
  ### Install theme on home directory
  home.file = {
    ### Ghostty
-   ".config/ghostty/config".source = ../../dotfiles/ghostty/config
+   ".config/ghostty/config".source = ../../dotfiles/ghostty/config;
  };
  
 }

--- a/profiles/hp-probook-profile.nix
+++ b/profiles/hp-probook-profile.nix
@@ -14,7 +14,7 @@
      ../configurations/modules/specific/vm/host/qemu-kvm-host.nix       ### To add qemu/kvm as an desktop hypervisor
      ../configurations/modules/specific/desktop/sound.nix               ### Sound server
     #../configurations/modules/specific/desktop/printer.nix             ### CUPS server
-     ../configurations/modules/specific/container/podman.nix            ### Enable podman and add distrobox as a system deps
+    #../configurations/modules/specific/container/podman.nix            ### Enable podman and add distrobox as a system deps
      ../configurations/modules/system/services/nix-channel-rm-dirs.nix  ### Related to remove nix-channel folder (unused on my case)
      ../configurations/modules/system/services/flatpak.nix              ### Add flatpak support
    ];


### PR DESCRIPTION
- **[nixpkgs/04ef94c4] add ghostty and change some option**
- **[nixpkgs/04ef94c4] add pre-setup for zen-browser and ghostty (for blur settings)**
- **[nixpkgs/04ef94c4] remove zen-browser from blurred application**
- **[nixpkgs/04ef94c4] home-manager: add ghostty config, and add apps.nix expression (to separate app config to theme)**
- **[nixpkgs/04ef94c4] home-manager/apps.nix: fix typo (forgot to add semicollon)**
- **[nixpkgs/04ef94c4] ghostty: change UbuntuMono font mono to no-mono font**
- **[nixpkgs/04ef94c4] ghostty: don't specify font (break aesthetic of the terminal)**
- **[nixpkgs/04ef94c4] gnome.nix: add nautilus-open-any-terminal option**
