### PR TITLE
home-manager: reorganize hm module to use easily home manager module on standalone configuration

### DIFF
--- a/configurations/config-modules/declarative-flatpak/default.nix
+++ b/configurations/config-modules/declarative-flatpak/default.nix
@@ -1,0 +1,24 @@
+{ config, pkgs, inputs, ... }:
+
+{
+ ### Import nix-flatpak like an expression
+ imports = [ inputs.declarative-flatpak.nixosModule ];
+
+ ### Declarative flatpak settings
+ services.flatpak = {
+   enable = true;
+   remotes = {
+     "flathub" = "https://flathub.org/repo/flathub.flatpakrepo";
+   };
+   packages = [
+     ### Argument order (to see commit, do "flatpak info software")
+   # {remote}:{type}/{ref}/[{arch}]/{branch}[:{commit}]
+     "flathub:app/io.github.shiftey.Desktop//stable"
+     "flathub:app/io.mrarm.mcpelauncher//stable"
+     #"com.usebottles.bottles"
+   ];
+ };
+ 
+ ### Enable xdg portal
+  xdg.portal.enable = true;
+}

--- a/configurations/config-modules/default.nix
+++ b/configurations/config-modules/default.nix
@@ -2,7 +2,8 @@
  ### Import all modules (specify what module to use in ../../profiles/<machine name>.nix to select a specific conf module)
  imports = [
    ./stylix
-   ./nix-flatpak
+   #./nix-flatpak
    ./nix-index-db
+   ./declarative-flatpak
  ];
 }

--- a/configurations/config-modules/nix-index-db/default.nix
+++ b/configurations/config-modules/nix-index-db/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, inputs, ... }:
+{ inputs, ... }:
 
 {
  ### Import nix-index-detabase module

--- a/flake.lock
+++ b/flake.lock
@@ -114,6 +114,22 @@
         "type": "github"
       }
     },
+    "declarative-flatpak": {
+      "locked": {
+        "lastModified": 1754772718,
+        "narHash": "sha256-AlYxWTqGiYlyMbMkh7Zt+2wekPxd3d1x6INbr2nQtTI=",
+        "owner": "in-a-dil-emma",
+        "repo": "declarative-flatpak",
+        "rev": "8ca8ff9fffb6c94561b74f79569a0ac0e43464c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "in-a-dil-emma",
+        "ref": "stable-v3",
+        "repo": "declarative-flatpak",
+        "type": "github"
+      }
+    },
     "dotfiles-minegameYTB": {
       "flake": false,
       "locked": {
@@ -405,22 +421,6 @@
         "type": "github"
       }
     },
-    "nix-flatpak": {
-      "locked": {
-        "lastModified": 1739444422,
-        "narHash": "sha256-iAVVHi7X3kWORftY+LVbRiStRnQEob2TULWyjMS6dWg=",
-        "owner": "gmodena",
-        "repo": "nix-flatpak",
-        "rev": "5e54c3ca05a7c7d968ae1ddeabe01d2a9bc1e177",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gmodena",
-        "ref": "latest",
-        "repo": "nix-flatpak",
-        "type": "github"
-      }
-    },
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
@@ -644,11 +644,11 @@
       "inputs": {
         "blocklist": "blocklist",
         "catppuccin-wallpapers": "catppuccin-wallpapers",
+        "declarative-flatpak": "declarative-flatpak",
         "dotfiles-minegameYTB": "dotfiles-minegameYTB",
         "ghostty": "ghostty",
         "home-manager": "home-manager",
         "lanzaboote": "lanzaboote",
-        "nix-flatpak": "nix-flatpak",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-23-11": "nixpkgs-23-11",

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,8 @@
    };
    ### Stylix - release-25.05 branch (Sept 2025)
    stylix.url = "github:danth/stylix/a9553a7486c86259b7678235cc26cfd70296251d";
-   nix-flatpak.url = "github:gmodena/nix-flatpak/latest";
+   #nix-flatpak.url = "github:gmodena/nix-flatpak/latest"; # For NixOS flatpak
+   declarative-flatpak.url = "github:in-a-dil-emma/declarative-flatpak/stable-v3"; # For HM standalone
    nix-index-database = {
      url = "github:nix-community/nix-index-database";
      inputs.nixpkgs.follows = "nixpkgs";
@@ -79,7 +80,8 @@
    stylix,
    home-manager,
    nur,
-   nix-flatpak,
+   #nix-flatpak,
+   declarative-flatpak,
    #nurpkgs-repo-minegameYTB,
    lanzaboote,
 

--- a/home-manager/configs/specific/standalone/config-modules/declarative-flatpak/default.nix
+++ b/home-manager/configs/specific/standalone/config-modules/declarative-flatpak/default.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, inputs, ... }:
+
+{
+ ### Import nix-flatpak like an expression
+ imports = [ inputs.declarative-flatpak.homeModule ];
+
+ ### Define flatpak environment variable
+ home.sessionVariables = {
+   XDG_DATA_DIRS = "$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:$XDG_DATA_DIRS";
+ };
+
+ ### Declarative flatpak settings
+ home.packages = with pkgs; [ flatpak ];
+
+ services.flatpak = {
+   enable = true;
+   remotes = {
+     "flathub" = "https://flathub.org/repo/flathub.flatpakrepo";
+   };
+   packages = [
+     "flathub:app/io.github.shiftey.Desktop//stable"
+     "flathub:app/io.mrarm.mcpelauncher//stable"
+     #"com.usebottles.bottles"
+   ];
+ };
+}

--- a/home-manager/configs/specific/standalone/config-modules/default.nix
+++ b/home-manager/configs/specific/standalone/config-modules/default.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+ ### Import expression for configuration modules (like configurations/config-modules in NixOS globale configuration)
+ imports = [
+   ./nix-index-db-hm
+   #./declarative-flatpak
+ ];
+}

--- a/home-manager/configs/specific/standalone/config-modules/nix-index-db-hm/default.nix
+++ b/home-manager/configs/specific/standalone/config-modules/nix-index-db-hm/default.nix
@@ -1,0 +1,9 @@
+{ inputs, ... }:
+
+{
+ ### Import nix-index-detabase module
+ imports = [ inputs.nix-index-database.homeModules.nix-index ];
+
+ ### Configure Nix index
+ programs.nix-index.enable = true;
+}

--- a/home-manager/configs/specific/standalone/default.nix
+++ b/home-manager/configs/specific/standalone/default.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+ ### Import expression for hm-standalone
+ imports = [
+   ./standalone-opts.nix
+
+   ### Add external module
+   ./config-modules
+ ];
+}

--- a/home-manager/configs/specific/standalone/standalone-opts.nix
+++ b/home-manager/configs/specific/standalone/standalone-opts.nix
@@ -1,0 +1,56 @@
+{ inputs, lib, config, pkgs, ... }:
+
+{
+ ### Initialise nur on home-manager standalone (already the case on hm-module on NixOS)
+ nixpkgs.overlays = [ inputs.nur.overlays.default ];
+ 
+ ### Environment variable
+ home.sessionVariables = {
+   PATH = "$HOME/.local/share/flatpak/exports/bin:/var/lib/flatpak/exports/bin:$PATH";
+ };
+
+ home.shellAliases = {
+   ### Aliases
+   nix = "nix --refresh -v --cores 2";
+   home-manager = "home-manager -b bak";
+
+   ### Git alias
+   gadd = "git add";
+   gpush = "git push";
+   gpull = "git pull";
+   gc = "git commit";
+   gsw = "git switch";
+   gbr = "git branch";
+   gft = "git fetch";
+
+   ### Core utilities remplacement
+   ls = "${pkgs.lsd}/bin/lsd";
+   cat = "${pkgs.bat}/bin/bat";
+   df = "${pkgs.duf}/bin/duf -hide special";
+
+   ### Original core utilities (from nixpkgs)
+   "ls.ori" = "${pkgs.coreutils}/bin/ls";
+   "cat.ori" = "${pkgs.coreutils}/bin/cat";
+   "df.ori" = "${pkgs.coreutils}/bin/df";
+
+   ### Use xterm-256color on runtime command
+   ssh = "TERM=xterm-256color ssh";
+
+   ### This alias is just inspired from macOS "open" command
+   open = "${pkgs.xdg-utils}/bin/xdg-open";
+ };
+
+ ### Nvd diff hook
+ home.activation = {
+   report-changes = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+     ### Define strict variable on this context
+     export PATH="${pkgs.nvd}/bin:${pkgs.coreutils}/bin:${pkgs.nix}/bin"
+     echo -e "\n===================================="
+     echo      "| Running nvd diff to show changes |"
+     echo -e   "====================================\n"
+     ### Variable found in activation script
+     nvd diff $oldGenPath $newGenPath
+     echo ""
+   '';
+ };
+}


### PR DESCRIPTION
home-manager: prepare configuration of nix index

home-manager: import correctly modules

home-manager: fix typo on nix-index module

home-manager: change nvd argument

home-manager: copy nix-flatpak configuration to test on hm standalone

home-manager: install flatpak from user env

home-manager: add declarative-flatpak to flake.nix

home-manager: add flatpak and there remote

home-manager: another change for flatpaks

flake.nix: replace nix-flatpak by declarative-flatpak

home-manager: add flatpak package to user env

home-manager: add XDG_DATA_DIRS variable for standalone hm

home-manager: include other path in PATH variable

home-manager: temporary disable declarative-flatpak config-modules
