### PR TITLE
add/ctrlos sources

### DIFF
--- a/configurations/configs/common/system-opts/nix-settings.nix
+++ b/configurations/configs/common/system-opts/nix-settings.nix
@@ -1,11 +1,17 @@
-{ config, pkgs, ... }:
+{ config, pkgs, inputs, ... }:
 
 {
  ### Nix Settings
  nix = {
    ### Directory relative to channel are removed with the service "nix-channel-rm-dirs.service"
    channel.enable = false;
-  #registry.nix-custom-repo.to = {
+   registry = {
+     ctrlos.to = {
+       type = "path";
+       path = inputs.ctrl-os;
+     };
+   };
+  #registry.nix-custom-repo.to = 
   #  owner = "minegameYTB";
   #  repo = "nix-custom-repo";
   #  type = "github";
@@ -16,12 +22,17 @@
      experimental-features = [ "nix-command" "flakes" "ca-derivations" ];
      max-jobs = 2;
      cores = 2;
+     
+     ### Substituers settings
      trusted-users = [ "@wheel" ];
+     substituters = [
+       "https://cache.ctrl-os.com/"
+     ];
      trusted-substituters = [
-       "https://hydra.nixos.org/"
+       "https://cache.ctrl-os.com/"
      ];
      trusted-public-keys = [
-       "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs="
+       "ctrl-os:baPzGxj33zp/P+GAIJXsr8ss9Law+qEEFViX1+flbv8="
      ];
    };
    gc = {

--- a/configurations/configs/common/system-pkgs.nix
+++ b/configurations/configs/common/system-pkgs.nix
@@ -1,4 +1,12 @@
-{ lib, inputs, config, pkgs, pkgsExtra, ghostty, ... }:
+{ 
+  lib,
+  inputs,
+  config,
+  pkgs,
+  pkgsExtra,
+  #ghostty,
+  ...
+}:
 
 let
   ### Add external packages
@@ -36,7 +44,8 @@ in
      onlyoffice-desktopeditors
 
      ### Ghostty
-     ghostty.packages.${pkgs.stdenvNoCC.hostPlatform.system}.default
+     #ghostty.packages.${pkgs.stdenvNoCC.hostPlatform.system}.default
+     ghostty ### Use ghostty from nixpkgs to unpin mesa version
    ]) ++ (with pkgsExtra.pkgs-unstable; [
      ### Extra GUI packages from pkgsExtra (only if X11 is enabled)
      #bottles

--- a/configurations/configs/specific/desktop/environment/gnome.nix
+++ b/configurations/configs/specific/desktop/environment/gnome.nix
@@ -78,8 +78,8 @@
 
  ### Nautilus settings
  programs.nautilus-open-any-terminal = {
-   enable = true;
-   terminal = "ghostty";
+ #  enable = true;
+ #  terminal = "ghostty";
  };
 
  ### Disable some services 

--- a/configurations/configs/specific/desktop/environment/gnome.nix
+++ b/configurations/configs/specific/desktop/environment/gnome.nix
@@ -29,6 +29,7 @@
      gnome-tweaks
      gnome-extension-manager
      showtime
+     evolution
 
      ### Themes
      ### Override papirus-icon-theme to set folder green
@@ -62,14 +63,14 @@
 
  ### Exclude some Gnome default packages
  environment.gnome.excludePackages = with pkgs; [
-   #geary                ### Geary
+   geary                ### Geary
    gnome-tour           ### Gnome Tour
    epiphany             ### Gnome Web
    yelp                 ### Gnome help
    totem                ### Gnome Totem (video)
    gnome-maps           ### Gnome maps
    gnome-connections    ### Gnome connections
-   #gnome-console        ### Gnome console (default term)
+   #gnome-console       ### Gnome console (default term)
    gnome-music          ### Gnome Music
    gnome-system-monitor ### Gnome system monitor
    gnome-software       ### Gnome software

--- a/configurations/configs/specific/desktop/x11.nix
+++ b/configurations/configs/specific/desktop/x11.nix
@@ -17,11 +17,11 @@
  hardware.graphics = {
    ### Fix mesa version on nixpkgs 25.05
    enable = true;
-   package = pkgsExtra.pkgs-25-05.mesa;
+   #package = pkgsExtra.pkgs-25-05.mesa;
    
    ### Enable 32-bit platform
    enable32Bit = true;
-   package32 = pkgsExtra.pkgs-25-05.pkgsi686Linux.mesa;
+   #package32 = pkgsExtra.pkgs-25-05.pkgsi686Linux.mesa;
  };
  ### Exclude Xterm 
  services.xserver.excludePackages = with pkgs; [

--- a/configurations/configs/specific/vm/host/qemu-kvm-host.nix
+++ b/configurations/configs/specific/vm/host/qemu-kvm-host.nix
@@ -21,17 +21,9 @@
      onBoot = "ignore";
      qemu.swtpm.enable = true;
    };
-   #libvirtd.qemu = {
-   #  package = pkgs.qemu_kvm;
-   #  ovmf.packages = [ pkgs.OVMFFull.fd ];
-   #  ovmf.enable = true;
-    #ovmf = {
-      #packages = [(pkgs.OVMF.override {
-      #  secureBoot = true;
-      #  tpmSupport = true;
-      #}).fd];
-     #};
-   #};
+   libvirtd.qemu = {
+     package = pkgs.qemu_kvm;
+   };
  };
 
  ### Nix specific

--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     "blocklist": {
       "flake": false,
       "locked": {
-        "lastModified": 1758991453,
-        "narHash": "sha256-TxPkUd457pTkEgIVG6UwkK2EWxvl816th7pDYwN9P4Q=",
+        "lastModified": 1759438725,
+        "narHash": "sha256-5tlkn2xRvy5SmafqxbWlTA4Ip5NYQVAjJ6WLTdx1Gjk=",
         "owner": "StevenBlack",
         "repo": "hosts",
-        "rev": "122b248d725bb2f25e0b250de0b263c0c4a30ea4",
+        "rev": "d2d175ed7adca0c8f0893f78d551b07eadc2a340",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
     },
     "nixpkgs-25-05": {
       "locked": {
-        "lastModified": 1759143472,
-        "narHash": "sha256-TvODmeR2W7yX/JmOCmP+lAFNkTT7hAxYcF3Kz8SZV3w=",
+        "lastModified": 1759439645,
+        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ed4e25ab58fd4c028b59d5611e14ea64de51d23",
+        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
     },
     "nixpkgs-main": {
       "locked": {
-        "lastModified": 1759143472,
-        "narHash": "sha256-TvODmeR2W7yX/JmOCmP+lAFNkTT7hAxYcF3Kz8SZV3w=",
+        "lastModified": 1759439645,
+        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ed4e25ab58fd4c028b59d5611e14ea64de51d23",
+        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
         "type": "github"
       },
       "original": {
@@ -548,11 +548,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759340767,
-        "narHash": "sha256-M3AwMhtQGipW1cSpNnKfpxDE8mNWBp8uBbWngx8h+fc=",
+        "lastModified": 1759578289,
+        "narHash": "sha256-w6+mGGDG1x6SdUfp3g2n2wHDBQFKKd861Nr63BwE0nY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "e9ad6dbc1abce2c321b691b08db554b5e086dd9a",
+        "rev": "fc81e15b9422a3457f8b0cb4d8c9a2fc2876fce6",
         "type": "github"
       },
       "original": {
@@ -882,11 +882,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1759292536,
-        "narHash": "sha256-fWTojLEpXgqwtKZb+qJ5gn9y8N6MAKM35yu0k+4yWmo=",
+        "lastModified": 1759584043,
+        "narHash": "sha256-YCuCmg9nRLrtTz7Zex94C8kYzh8hoSzPOA72kMLpuxM=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "d11cff279fb1d879cd72d6fb3bbd1ae7b584674b",
+        "rev": "176555a4128ce90461354142ab85c7f536bfd267",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -114,6 +114,18 @@
         "type": "github"
       }
     },
+    "ctrl-os": {
+      "locked": {
+        "lastModified": 1759507780,
+        "narHash": "sha256-w4PC8XawDAGMSEDCl794JiMn+yqh9lzL4L6Yr1L2rdk=",
+        "type": "tarball",
+        "url": "https://channels.ctrl-os.com/permanent/ctrlos-b274108fb212cc0cbc39816cdaf018891d060a35.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.ctrl-os.com/channel/ctrlos-24.05.tar.xz"
+      }
+    },
     "declarative-flatpak": {
       "locked": {
         "lastModified": 1758787189,
@@ -660,6 +672,7 @@
       "inputs": {
         "blocklist": "blocklist",
         "catppuccin-wallpapers": "catppuccin-wallpapers",
+        "ctrl-os": "ctrl-os",
         "declarative-flatpak": "declarative-flatpak",
         "dotfiles-minegameYTB": "dotfiles-minegameYTB",
         "ghostty": "ghostty",

--- a/flake.lock
+++ b/flake.lock
@@ -578,22 +578,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_2",
@@ -879,7 +863,9 @@
     "zen-browser": {
       "inputs": {
         "home-manager": "home-manager_2",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": [
+          "nixpkgs-main"
+        ]
       },
       "locked": {
         "lastModified": 1759584043,

--- a/flake.lock
+++ b/flake.lock
@@ -177,22 +177,6 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
@@ -269,24 +253,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "fromYaml": {
       "flake": false,
       "locked": {
@@ -300,29 +266,6 @@
       "original": {
         "owner": "SenchoPens",
         "repo": "fromYaml",
-        "type": "github"
-      }
-    },
-    "ghostty": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "zig": "zig",
-        "zon2nix": "zon2nix"
-      },
-      "locked": {
-        "lastModified": 1748879102,
-        "narHash": "sha256-Q8UpTl4EB73Od3pc7H09aM8mEa7VpIS2vX/mu69oAKk=",
-        "owner": "ghostty-org",
-        "repo": "ghostty",
-        "rev": "5306e7cf567ccb37028701a00504bcf28484b155",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ghostty-org",
-        "repo": "ghostty",
-        "rev": "5306e7cf567ccb37028701a00504bcf28484b155",
         "type": "github"
       }
     },
@@ -410,7 +353,7 @@
     "lanzaboote": {
       "inputs": {
         "crane": "crane",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs-main"
@@ -455,15 +398,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748189127,
-        "narHash": "sha256-zRDR+EbbeObu4V2X5QCd2Bk5eltfDlCr5yvhBwUT6pY=",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/25.05/nixos-25.05.802491.7c43f080a7f2/nixexprs.tar.xz"
+        "lastModified": 1751211869,
+        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz"
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-23-11": {
@@ -494,22 +440,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-25-05": {
-      "locked": {
-        "lastModified": 1759439645,
-        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -558,22 +488,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1751211869,
-        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -659,13 +573,11 @@
         "ctrl-os": "ctrl-os",
         "declarative-flatpak": "declarative-flatpak",
         "dotfiles-minegameYTB": "dotfiles-minegameYTB",
-        "ghostty": "ghostty",
         "home-manager": "home-manager",
         "lanzaboote": "lanzaboote",
         "nix-index-database": "nix-index-database",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-24-11": "nixpkgs-24-11",
-        "nixpkgs-25-05": "nixpkgs-25-05",
         "nixpkgs-main": "nixpkgs-main",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
@@ -703,9 +615,9 @@
         "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-parts": "flake-parts_3",
         "gnome-shell": "gnome-shell",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nur": "nur_2",
-        "systems": "systems_2",
+        "systems": "systems",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -728,21 +640,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -878,60 +775,6 @@
       "original": {
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "type": "github"
-      }
-    },
-    "zig": {
-      "inputs": {
-        "flake-compat": [
-          "ghostty"
-        ],
-        "flake-utils": [
-          "ghostty",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "ghostty",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1748261582,
-        "narHash": "sha256-3i0IL3s18hdDlbsf0/E+5kyPRkZwGPbSFngq5eToiAA=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "aafb1b093fb838f7a02613b719e85ec912914221",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zon2nix": {
-      "inputs": {
-        "flake-utils": [
-          "ghostty",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "ghostty",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1742104771,
-        "narHash": "sha256-LhidlyEA9MP8jGe1rEnyjGFCzLLgCdDpYeWggibayr0=",
-        "owner": "jcollie",
-        "repo": "zon2nix",
-        "rev": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jcollie",
-        "ref": "56c159be489cc6c0e73c3930bd908ddc6fe89613",
-        "repo": "zon2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,10 @@
      url = "github:nix-community/home-manager/release-25.05";
      inputs.nixpkgs.follows = "nixpkgs-main";
    };
-   zen-browser.url = "github:0xc000022070/zen-browser-flake";
+   zen-browser = {
+     url = "github:0xc000022070/zen-browser-flake";
+     inputs.nixpkgs.follows = "nixpkgs-main";
+   };
    nur = {
      url = "github:nix-community/nur";
      inputs.nixpkgs.follows = "nixpkgs-main";

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
    ### github:username/repo?ref=pull/<PR number>/head
 
    ### Other nixpkgs repos
+   ctrl-os.url = "https://channels.ctrl-os.com/channel/ctrlos-24.05.tar.xz";
    nixpkgs-23-11.url = "github:NixOS/nixpkgs/nixos-23.11";
    nixpkgs-24-11.url = "github:NixOS/nixpkgs/nixos-24.11";
    nixpkgs-25-05.url = "github:NixOS/nixpkgs/nixos-25.05"; # To pin mesa version temporairy for ghostty bug
@@ -71,10 +72,11 @@
    nixpkgs-main,
 
    ### Other nixpkgs sources
-   nixpkgs-unstable,
+   ctrl-os,
    nixpkgs-23-11,
    nixpkgs-24-11,
    nixpkgs-25-05,
+   nixpkgs-unstable,
    #nixpkgs-master,
    #nixpkgs-pr,
 
@@ -139,6 +141,10 @@
 
    ### Other sources (pkgs set)
    pkgsExtra = system: {
+     pkgs-lts = import ctrl-os {
+       inherit system;
+       config = nixpkgsConfig;
+     };
      pkgs-23-11 = import nixpkgs-23-11 {
        inherit system;
        config = nixpkgsConfig;

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
    ctrl-os.url = "https://channels.ctrl-os.com/channel/ctrlos-24.05.tar.xz";
    nixpkgs-23-11.url = "github:NixOS/nixpkgs/nixos-23.11";
    nixpkgs-24-11.url = "github:NixOS/nixpkgs/nixos-24.11";
-   nixpkgs-25-05.url = "github:NixOS/nixpkgs/nixos-25.05"; # To pin mesa version temporairy for ghostty bug
+   #nixpkgs-25-05.url = "github:NixOS/nixpkgs/nixos-25.05";
    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
    
    ### Upstream nixpkgs repo (pin git hash)
@@ -45,7 +45,7 @@
      inputs.nixpkgs.follows = "nixpkgs-main";
    };
    #nurpkgs-repo-minegameYTB.url = "github:minegameYTB/nurpkgs-repo";
-   ghostty.url = "github:ghostty-org/ghostty/5306e7cf567ccb37028701a00504bcf28484b155";
+   #ghostty.url = "github:ghostty-org/ghostty/5306e7cf567ccb37028701a00504bcf28484b155";
 
    ### Rice/customization
    catppuccin-wallpapers = {
@@ -78,7 +78,7 @@
    ctrl-os,
    nixpkgs-23-11,
    nixpkgs-24-11,
-   nixpkgs-25-05,
+   #nixpkgs-25-05,
    nixpkgs-unstable,
    #nixpkgs-master,
    #nixpkgs-pr,
@@ -93,7 +93,7 @@
    lanzaboote,
 
    ### Sources for 3rd part software
-   ghostty,
+   #ghostty,
    zen-browser,
    ...
  }@inputs:
@@ -156,10 +156,10 @@
        inherit system;
        config = nixpkgsConfig;
      };
-     pkgs-25-05 = import nixpkgs-25-05 {
-       inherit system;
-       config = nixpkgsConfig;
-     };
+     #pkgs-25-05 = import nixpkgs-25-05 {
+     #  inherit system;
+     #  config = nixpkgsConfig;
+     #};
      pkgs-unstable = import nixpkgs-unstable {
        inherit system;
        config = nixpkgsConfig;
@@ -178,7 +178,10 @@
    specialArgs = system: {
      inherit inputs;
      pkgsExtra = pkgsExtra system;
-     inherit (inputs) zen-browser ghostty; 
+     inherit (inputs)
+       zen-browser 
+       #ghostty
+     ; 
      #inherit (inputs) nurpkgs-repo-minegameYTB;
    };
 

--- a/profiles/hp-probook-profile.nix
+++ b/profiles/hp-probook-profile.nix
@@ -37,6 +37,6 @@
    ../configurations/config-modules
 
    ### Add lanzaboote (separate module)
-   ../configurations/config-modules/lanzaboote
+   #../configurations/config-modules/lanzaboote
  ];
 }


### PR DESCRIPTION
- **add ctrl-os sources (and add ctrl-os to nix registry)**
- **[nixpkgs/25.05.20251002.879bd46] flake.lock: update to the new rev**
- **gnome.nix: replace geary for evolution (mail client)**
- **secure-boot: disable secure boot bootloader for hp-probook**
- **Update qemu-kvm-host.nix**
- **flake.nix: zen-browser flake will use nixpkgs-main branch now (stable branch of this configuration)**
- **flake.nix: unpin mesa version and changes ghostty repo to nixpkgs repo**
